### PR TITLE
pyfhel 3.4.2 :snowflake:

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,2 @@
+upload_channels:
+  - sfe1ed40

--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -1,0 +1,3 @@
+set CFLAGS="-isystem %PREFIX%\\include\\SEAL-4.1 %CFLAGS%"
+
+%PYTHON% -m pip install . --no-deps --no-build-isolation -vv

--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -1,3 +1,11 @@
-set CFLAGS="-isystem %PREFIX%\\include\\SEAL-4.1 %CFLAGS%"
+:: we unvendored Seal so this is the include to the headers
+set INCLUDE=%INCLUDE%;%PREFIX%\Library\include\SEAL-4.1
+@REM echo ====
+@REM echo %PREFIX%\Library\include\SEAL-4.1
+@REM echo ====
+@REM dir %PREFIX%\Library\include\SEAL-4.1
+@REM echo ====
+@REM dir %PREFIX%\Library\lib
+@REM echo ====
 
 %PYTHON% -m pip install . --no-deps --no-build-isolation -vv

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
 
+# we unvendored Seal so this is the include to the headers
 export CFLAGS="-isystem ${PREFIX}/include/SEAL-4.1 ${CFLAGS}"
 
 ${PYTHON} -m pip install . --no-deps --no-build-isolation -vv

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+
+export CFLAGS="-isystem ${PREFIX}/include/SEAL-4.1 ${CFLAGS}"
+
+${PYTHON} -m pip install . --no-deps --no-build-isolation -vv

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -1,0 +1,6 @@
+MACOSX_SDK_VERSION:        # [osx and x86_64]
+  - "10.15"                # [osx and x86_64]
+MACOSX_DEPLOYMENT_TARGET:  # [osx and x86_64]
+  - "10.15"                # [osx and x86_64]
+CONDA_BUILD_SYSROOT:       # [osx and x86_64]
+  - /opt/MacOSX10.15.sdk   # [osx and x86_64]

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -1,6 +1,0 @@
-MACOSX_SDK_VERSION:        # [osx and x86_64]
-  - "10.15"                # [osx and x86_64]
-MACOSX_DEPLOYMENT_TARGET:  # [osx and x86_64]
-  - "10.15"                # [osx and x86_64]
-CONDA_BUILD_SYSROOT:       # [osx and x86_64]
-  - /opt/MacOSX10.15.sdk   # [osx and x86_64]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -15,7 +15,10 @@ source:
 build:
   number: 0
   missing_dso_whitelist:
-    - '*/ld64.so.1'  # [s390x]
+    - '*/ld64.so.1'          # [s390x]
+    - '*/libc++.1.dylib'     # [osx]
+    - '*/libzstd.1.dylib'    # [osx]
+    - '*/libz.1.dylib'       # [osx]
 
 requirements:
   build:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -14,6 +14,11 @@ source:
 
 build:
   number: 0
+  missing_dso_whitelist:
+    - '*/libc++.1.dylib'  # [osx]
+    - '*/libomp.dylib'    # [osx]
+    - '*/libzstd.so.1'    # [osx]
+    - '*/libz.so.1'       # [osx]
 
 requirements:
   build:
@@ -31,9 +36,10 @@ requirements:
     - numpy >=1.21
     - toml >=0.1
     - seal
-    # openmp for win: see the conda_build_config.yaml
     - llvm-openmp   # [osx]
     - libgomp       # [linux]
+    - zlib {{ zlib }}
+    - zstd {{ zstd }}
   run:
     - numpy >=1.21
     - python

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -14,6 +14,8 @@ source:
 
 build:
   number: 0
+  missing_dso_whitelist:
+    - '*/ld64.so.1'  # [s390x]
 
 requirements:
   build:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -6,8 +6,8 @@ package:
   version: {{ version }}
 
 source:
-  url: https://pypi.io/packages/source/{{ name[0]|lower }}/{{ name|lower }}/{{ name }}-{{ version }}.tar.gz
-  sha256: fa41664f8815b27f6347821f6363a7516fa84f50570816d8f292f2c22f88f88c
+  url: https://github.com/ibarrond/Pyfhel/archive/refs/tags/v{{ version }}.tar.gz
+  sha256: 37825ce03a54e7ca9e2d39f6fd4bf19e4d58ec28cd856fe4d7a0fef4cefed5bf
   patches:
     - patches/0001-no-system-include.patch
     - patches/0002-unvendor-seal.patch
@@ -53,8 +53,14 @@ test:
     - Pyfhel.utils
   requires:
     - pip
+    - pytest
+  source_files:
+    - Pyfhel/test
+    - examples
+    - pyproject.toml
   commands:
     - pip check
+    - pytest -v .
 
 about:
   home: https://pyfhel.readthedocs.io

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -17,7 +17,6 @@ build:
   # osx gives a python Abort trap: 6 on tests, for more info
   # have a look at:
   # https://github.com/AnacondaRecipes/pyfhel-feedstock/pull/1
-  skip: true  # [osx]
   # win builds, but can't import Pyfhel, something is missing.
   # On the next update it should be investigated and completed.
   skip: true  # [win]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -56,7 +56,7 @@ test:
 about:
   home: https://pyfhel.readthedocs.io
   license: "GNU General Public v3 (GPLv3)"
-  license_family: GPL-3.0
+  license_family: GPL3
   license_file:
     - LICENSE.txt
     - Pyfhel/backend/SEAL/LICENSE

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -14,11 +14,6 @@ source:
 
 build:
   number: 0
-  missing_dso_whitelist:
-    - '*/libc++.1.dylib'  # [osx]
-    - '*/libomp.dylib'    # [osx]
-    - '*/libzstd.so.1'    # [osx]
-    - '*/libz.so.1'       # [osx]
 
 requirements:
   build:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -17,6 +17,7 @@ build:
   # osx gives a python Abort trap: 6 on tests, for more info
   # have a look at:
   # https://github.com/AnacondaRecipes/pyfhel-feedstock/pull/1
+  skip: true  # [osx]
   # win builds, but can't import Pyfhel, something is missing.
   # On the next update it should be investigated and completed.
   skip: true  # [win]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -14,6 +14,10 @@ source:
 
 build:
   number: 0
+  # osx gives a python Abort trap: 6 on tests, for more info
+  # have a look at:
+  # https://github.com/AnacondaRecipes/pyfhel-feedstock/pull/1
+  skip: true  # [osx]
   # win builds, but can't import Pyfhel, something is missing.
   # On the next update it should be investigated and completed.
   skip: true  # [win]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -56,13 +56,13 @@ test:
 about:
   home: https://pyfhel.readthedocs.io
   license: "GNU General Public v3 (GPLv3)"
-  license_family: GPL3
+  license_family: GPL-3.0
   license_file:
     - LICENSE.txt
     - Pyfhel/backend/SEAL/LICENSE
   summary: "Python for Homomorphic Encryption Libraries"
   doc_url: https://pyfhel.readthedocs.io
-  dev_url: https://github.com/ibarrond/github
+  dev_url: https://github.com/ibarrond/Pyfhel
 
 extra:
   recipe-maintainers:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -40,7 +40,7 @@ requirements:
     - setuptools
     - wheel
     - cython >=3.0.0
-    - numpy >=1.21
+    - numpy {{ numpy }}
     - toml >=0.1
     - seal
     - llvm-openmp   # [osx]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,0 +1,59 @@
+{% set name = "Pyfhel" %}
+{% set version = "3.4.2" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  url: https://pypi.io/packages/source/{{ name[0]|lower }}/{{ name|lower }}/{{ name }}-{{ version }}.tar.gz
+  sha256: fa41664f8815b27f6347821f6363a7516fa84f50570816d8f292f2c22f88f88c
+  # patches:
+  #   - patches/0001-no-system-include.patch
+
+build:
+  number: 0
+  script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
+
+requirements:
+  build:
+    - {{ compiler('c') }}
+    - {{ compiler('cxx') }}
+    - cmake >=3.15
+    # - patch     # [not win]
+    # - m2-patch  # [win]
+  host:
+    - python
+    - pip
+    - setuptools
+    - wheel
+    - cython >=3.0.0
+    - numpy >=1.21
+    - toml >=0.1
+  run:
+    - numpy >=1.21
+    - python
+
+test:
+  imports:
+    - Pyfhel
+    - Pyfhel.utils
+  requires:
+    - pip
+  commands:
+    - pip check
+
+about:
+  home: https://pyfhel.readthedocs.io
+  license: "GNU General Public v3 (GPLv3)"
+  license_family: GPL3
+  license_file:
+    - LICENSE.txt
+    - Pyfhel/backend/SEAL/LICENSE
+  summary: "Python for Homomorphic Encryption Libraries"
+  doc_url: https://pyfhel.readthedocs.io
+  dev_url: https://github.com/ibarrond/github
+
+extra:
+  recipe-maintainers:
+    - lorepirri

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -8,20 +8,20 @@ package:
 source:
   url: https://pypi.io/packages/source/{{ name[0]|lower }}/{{ name|lower }}/{{ name }}-{{ version }}.tar.gz
   sha256: fa41664f8815b27f6347821f6363a7516fa84f50570816d8f292f2c22f88f88c
-  # patches:
-  #   - patches/0001-no-system-include.patch
+  patches:
+    - patches/0001-no-system-include.patch
+    - patches/0002-unvendor-seal.patch
 
 build:
   number: 0
-  script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
 
 requirements:
   build:
     - {{ compiler('c') }}
     - {{ compiler('cxx') }}
     - cmake >=3.15
-    # - patch     # [not win]
-    # - m2-patch  # [win]
+    - patch     # [not win]
+    - m2-patch  # [win]
   host:
     - python
     - pip
@@ -30,6 +30,10 @@ requirements:
     - cython >=3.0.0
     - numpy >=1.21
     - toml >=0.1
+    - seal
+    # openmp for win: see the conda_build_config.yaml
+    - llvm-openmp   # [osx]
+    - libgomp       # [linux]
   run:
     - numpy >=1.21
     - python

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -14,6 +14,9 @@ source:
 
 build:
   number: 0
+  # win builds, but can't import Pyfhel, something is missing.
+  # On the next update it should be investigated and completed.
+  skip: true  # [win]
   missing_dso_whitelist:
     - '*/ld64.so.1'          # [s390x]
     - '*/libc++.1.dylib'     # [osx]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -55,12 +55,16 @@ test:
 
 about:
   home: https://pyfhel.readthedocs.io
-  license: "GNU General Public v3 (GPLv3)"
-  license_family: GPL3
-  license_file:
-    - LICENSE.txt
-    - Pyfhel/backend/SEAL/LICENSE
-  summary: "Python for Homomorphic Encryption Libraries"
+  license: Apache-2.0
+  license_family: Apache
+  license_file: LICENSE.txt
+  summary: Python for Homomorphic Encryption Libraries
+  description: |
+    Python library for Addition, Subtraction, Multiplication and
+    Scalar Product over encrypted integers (BFV/BGV schemes) and
+    approximated floating point values (CKKS scheme). This library
+    acts as an optimized Python API for C++ Homomorphic Encryption
+    libraries.
   doc_url: https://pyfhel.readthedocs.io
   dev_url: https://github.com/ibarrond/Pyfhel
 

--- a/recipe/patches/0001-no-system-include.patch
+++ b/recipe/patches/0001-no-system-include.patch
@@ -1,0 +1,25 @@
+From bf16dca1bbe48f5684b78f9ba2a058b955ed01e1 Mon Sep 17 00:00:00 2001
+From: Lorenzo Pirritano <lpirritano@anaconda.com>
+Date: Tue, 19 Mar 2024 07:58:17 -0600
+Subject: [PATCH] no-system-include
+
+---
+ pyproject.toml | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/pyproject.toml b/pyproject.toml
+index 5f8b346..1c7579e 100644
+--- a/pyproject.toml
++++ b/pyproject.toml
+@@ -150,7 +150,7 @@ platforms = ["Linux", "Windows", "Darwin"]
+ #----------------------------- CYTHON EXTENSIONS -------------------------------
+ [extensions.config]   # Common compilation config for all extensions
+ include_dirs = [
+-    {Darwin = ["/usr/local/include"]},
++    {Darwin = []},
+ ]
+ define_macros = [
+   ["NPY_NO_DEPRECATED_API", "NPY_1_7_API_VERSION"],
+-- 
+2.39.1
+

--- a/recipe/patches/0001-no-system-include.patch
+++ b/recipe/patches/0001-no-system-include.patch
@@ -1,7 +1,7 @@
-From bf16dca1bbe48f5684b78f9ba2a058b955ed01e1 Mon Sep 17 00:00:00 2001
+From 0d94817308d14f08da33fd0fd0e2d0ac08904d5b Mon Sep 17 00:00:00 2001
 From: Lorenzo Pirritano <lpirritano@anaconda.com>
-Date: Tue, 19 Mar 2024 07:58:17 -0600
-Subject: [PATCH] no-system-include
+Date: Mon, 15 Apr 2024 22:48:14 -0600
+Subject: [PATCH 1/2] no-system-include
 
 ---
  pyproject.toml | 2 +-

--- a/recipe/patches/0002-unvendor-seal.patch
+++ b/recipe/patches/0002-unvendor-seal.patch
@@ -1,17 +1,32 @@
-From 5b1c80418e9e3ab102f8f48a0cb3e45bac90775b Mon Sep 17 00:00:00 2001
+From 4b8e6bbd9a3c2e01747aa4766a0642ec9f60f29c Mon Sep 17 00:00:00 2001
 From: Lorenzo Pirritano <lpirritano@anaconda.com>
-Date: Wed, 27 Mar 2024 15:49:02 -0600
+Date: Thu, 28 Mar 2024 00:53:56 -0600
 Subject: [PATCH] unvendor-seal
 
 ---
- pyproject.toml | 37 ++++---------------------------------
- 1 file changed, 4 insertions(+), 33 deletions(-)
+ Pyfhel.egg-info/SOURCES.txt |  2 +-
+ pyproject.toml              | 39 +++++--------------------------------
+ setup.py                    |  7 +++++--
+ 3 files changed, 11 insertions(+), 37 deletions(-)
 
+diff --git a/Pyfhel.egg-info/SOURCES.txt b/Pyfhel.egg-info/SOURCES.txt
+index 1469508..564ebdf 100644
+--- a/Pyfhel.egg-info/SOURCES.txt
++++ b/Pyfhel.egg-info/SOURCES.txt
+@@ -4,7 +4,7 @@ README.md
+ pyproject.toml
+ setup.cfg
+ setup.py
+-/Users/alberto.ibarrondo/Technocracy/workspace/Pyfhel/Pyfhel/Afhel/Afseal.cpp
++Pyfhel/Afhel/Afseal.cpp
+ Pyfhel/PyCtxt.pxd
+ Pyfhel/PyCtxt.pyx
+ Pyfhel/PyPoly.pxd
 diff --git a/pyproject.toml b/pyproject.toml
-index 1c7579e..efbeda7 100644
+index 1c7579e..bf7c73d 100644
 --- a/pyproject.toml
 +++ b/pyproject.toml
-@@ -97,35 +97,6 @@ platforms = ["Linux", "Windows", "Darwin"]
+@@ -97,44 +97,15 @@ platforms = ["Linux", "Windows", "Darwin"]
  #------------------------------ C/C++ LIBRARIES --------------------------------
  [cpplibraries]
  
@@ -47,9 +62,10 @@ index 1c7579e..efbeda7 100644
    #--> Afhel
    [cpplibraries.Afhel]
    mode = 'standard'        # standard/cmake
-@@ -133,8 +104,8 @@ platforms = ["Linux", "Windows", "Darwin"]
+   lib_type = 'shared'      # static/shared
    sources = ['Pyfhel/Afhel/Afseal.cpp',]
-   include_dirs = ['Pyfhel/Afhel',]
+-  include_dirs = ['Pyfhel/Afhel',]
++  include_dirs = ['Pyfhel/Afhel']
    define_macros = [
 -    # ["SEAL_USE_ZLIB","0"],
 -    # ["SEAL_USE_ZSTD","0"],
@@ -76,6 +92,31 @@ index 1c7579e..efbeda7 100644
  
  # List of extensions to compile. Custom compilation config can be defined for each
  [extensions.Pyfhel]
+diff --git a/setup.py b/setup.py
+index 02754c4..68d4bc8 100755
+--- a/setup.py
++++ b/setup.py
+@@ -452,7 +452,10 @@ class SuperBuildClib(build_clib):
+                 f.write(f"add_compile_options({extra_c_args})\n")
+             for d in build_info['include_dirs']:
+                 f.write(f"include_directories(\"{d}\")\n")
+-            macros = [f"-d{m[0]}={m[1]}" for m in build_info['macros']]
++            f.write("include_directories(\"$ENV{PREFIX}/Library/include\")\n")
++            f.write("include_directories(\"$ENV{PREFIX}/Library/include/SEAL-4.1\")\n")
++            
++            macros = [f"-D{m[0]}={m[1]}" for m in build_info['macros']]
+             if macros:
+                 f.write(f"add_compile_options({' '.join(macros)})\n")
+             extra_l_args = ' '.join(build_info['extra_link_args'])
+@@ -624,7 +627,7 @@ for ext_name, ext_conf in extensions.items():
+         name            = ext_conf.pop('fullname', f"{project_name}.{ext_name}"),
+         sources         =_npath(_pl(ext_conf.pop('sources', []))),
+         include_dirs    = _path(_pl(ext_conf.pop('include_dirs', [])))      + include_dirs,
+-        define_macros   = _tupl(_pl(ext_conf.pop('include_dirs', [])))      + define_macros,
++        define_macros   = _tupl(_pl(ext_conf.pop('define_macros', [])))      + define_macros,
+         language        = "c++",
+         extra_compile_args=     _pl(ext_conf.pop('extra_compile_args', [])) + extra_compile_args,
+         extra_link_args =       _pl(ext_conf.pop('extra_link_args', []))    + extra_link_args,
 -- 
 2.39.1
 

--- a/recipe/patches/0002-unvendor-seal.patch
+++ b/recipe/patches/0002-unvendor-seal.patch
@@ -1,0 +1,61 @@
+From 81a5f0feb78127e1060f0ba7474858dc9b74fa93 Mon Sep 17 00:00:00 2001
+From: Lorenzo Pirritano <lpirritano@anaconda.com>
+Date: Thu, 21 Mar 2024 21:35:49 -0600
+Subject: [PATCH] unvendor-seal
+
+---
+ pyproject.toml | 31 +------------------------------
+ 1 file changed, 1 insertion(+), 30 deletions(-)
+
+diff --git a/pyproject.toml b/pyproject.toml
+index 1c7579e..5a2b9f7 100644
+--- a/pyproject.toml
++++ b/pyproject.toml
+@@ -97,35 +97,6 @@ platforms = ["Linux", "Windows", "Darwin"]
+ #------------------------------ C/C++ LIBRARIES --------------------------------
+ [cpplibraries]
+ 
+-  #--> SEAL
+-  [cpplibraries.SEAL]
+-  mode = 'cmake'              # standard/cmake
+-  lib_type = 'static'         # static/shared
+-  # source_dir: dir with the top CMakeLists.txt.
+-  source_dir = 'Pyfhel/backend/SEAL'
+-  include_dirs = [
+-    'Pyfhel/backend/SEAL/native/src',
+-    'Pyfhel/backend/SEAL/thirdparty/msgsl-src/include'
+-  ]
+-
+-  ## Build-relative dirs:
+-  #  -> paths are relative to build directory.
+-  # built_library_dir: output dir containing the cmake-built libs
+-  built_library_dir='lib' 
+-  # built_include_dirs: dirs with cmake-built headers.
+-  built_include_dirs=['native/src', 'thirdparty/msgsl-src/include']
+-
+-  ## CMake options: https://github.com/microsoft/SEAL/#basic-cmake-options
+-    [cpplibraries.SEAL.cmake_opts]
+-    CMAKE_BUILD_TYPE = 'Release'
+-    SEAL_USE_INTEL_HEXL ='OFF'   # ON/OFF, use Intel HEXL for low-level kernels
+-    SEAL_USE_ALIGNED_ALLOC ='OFF'# ON/OFF, 64B aligned memory allocations, better perf with Intel HEXL.
+-    BUILD_SHARED_LIBS ='OFF'     # ON/OFF, build shared and not static library
+-    SEAL_THROW_ON_TRANSPARENT_CIPHERTEXT='ON' # ON/OFF, runtime error when multiplying a ctxt with a zeroed plaintext.
+-    SEAL_USE_MSGSL = 'ON'       # ON/OFF,	Build with Microsoft GSL support.
+-    SEAL_USE_ZLIB	= 'ON'        # ON/OFF,	Build with ZLIB support.
+-    SEAL_USE_ZSTD	= 'ON'        # ON/OFF,	Build with Zstandard support.
+-    
+   #--> Afhel
+   [cpplibraries.Afhel]
+   mode = 'standard'        # standard/cmake
+@@ -144,7 +115,7 @@ platforms = ["Linux", "Windows", "Darwin"]
+     {Windows = []},
+     {Darwin = ["-Wl,-rpath,@loader_path/.", "-fopenmp","-Wl,-no_compact_unwind"]},
+     {Linux = ["-Wl,-rpath=$ORIGIN/.", "-fopenmp"]} ]
+-  libraries = ['SEAL']
++  libraries = ['seal-4.1']
+ 
+ 
+ #----------------------------- CYTHON EXTENSIONS -------------------------------
+-- 
+2.39.1
+

--- a/recipe/patches/0002-unvendor-seal.patch
+++ b/recipe/patches/0002-unvendor-seal.patch
@@ -1,14 +1,14 @@
-From 81a5f0feb78127e1060f0ba7474858dc9b74fa93 Mon Sep 17 00:00:00 2001
+From 5b1c80418e9e3ab102f8f48a0cb3e45bac90775b Mon Sep 17 00:00:00 2001
 From: Lorenzo Pirritano <lpirritano@anaconda.com>
-Date: Thu, 21 Mar 2024 21:35:49 -0600
+Date: Wed, 27 Mar 2024 15:49:02 -0600
 Subject: [PATCH] unvendor-seal
 
 ---
- pyproject.toml | 31 +------------------------------
- 1 file changed, 1 insertion(+), 30 deletions(-)
+ pyproject.toml | 37 ++++---------------------------------
+ 1 file changed, 4 insertions(+), 33 deletions(-)
 
 diff --git a/pyproject.toml b/pyproject.toml
-index 1c7579e..5a2b9f7 100644
+index 1c7579e..efbeda7 100644
 --- a/pyproject.toml
 +++ b/pyproject.toml
 @@ -97,35 +97,6 @@ platforms = ["Linux", "Windows", "Darwin"]
@@ -47,15 +47,35 @@ index 1c7579e..5a2b9f7 100644
    #--> Afhel
    [cpplibraries.Afhel]
    mode = 'standard'        # standard/cmake
+@@ -133,8 +104,8 @@ platforms = ["Linux", "Windows", "Darwin"]
+   sources = ['Pyfhel/Afhel/Afseal.cpp',]
+   include_dirs = ['Pyfhel/Afhel',]
+   define_macros = [
+-    # ["SEAL_USE_ZLIB","0"],
+-    # ["SEAL_USE_ZSTD","0"],
++    ["SEAL_USE_ZLIB","1"],
++    ["SEAL_USE_ZSTD","1"],
+   ]
+   extra_compile_args = [
+     {Windows = ["/O2","/std:c++17","/openmp"]},
 @@ -144,7 +115,7 @@ platforms = ["Linux", "Windows", "Darwin"]
      {Windows = []},
      {Darwin = ["-Wl,-rpath,@loader_path/.", "-fopenmp","-Wl,-no_compact_unwind"]},
      {Linux = ["-Wl,-rpath=$ORIGIN/.", "-fopenmp"]} ]
 -  libraries = ['SEAL']
-+  libraries = ['seal-4.1']
++  libraries = ['seal-4.1','z','zstd']
  
  
  #----------------------------- CYTHON EXTENSIONS -------------------------------
+@@ -166,7 +137,7 @@ extra_link_args = [
+   {Darwin = ["-Wl,-rpath,@loader_path/.", "-fopenmp","-Wl,-no_compact_unwind"]},
+   {Linux = ["-Wl,-rpath=$ORIGIN/.", "-fopenmp"]},
+ ]
+-libraries = []  # libraries to link with, cpplibraries above are added by default
++libraries = ['seal-4.1','z','zstd']  # libraries to link with, cpplibraries above are added by default
+ 
+ # List of extensions to compile. Custom compilation config can be defined for each
+ [extensions.Pyfhel]
 -- 
 2.39.1
 

--- a/recipe/patches/0002-unvendor-seal.patch
+++ b/recipe/patches/0002-unvendor-seal.patch
@@ -1,35 +1,22 @@
-From 4b8e6bbd9a3c2e01747aa4766a0642ec9f60f29c Mon Sep 17 00:00:00 2001
+From 94c1830eada73a3e856da0e06e47d75b800cc8b2 Mon Sep 17 00:00:00 2001
 From: Lorenzo Pirritano <lpirritano@anaconda.com>
-Date: Thu, 28 Mar 2024 00:53:56 -0600
-Subject: [PATCH] unvendor-seal
+Date: Wed, 17 Apr 2024 07:57:25 -0600
+Subject: [PATCH 2/2] unvendor-seal
 
 ---
- Pyfhel.egg-info/SOURCES.txt |  2 +-
- pyproject.toml              | 39 +++++--------------------------------
- setup.py                    |  7 +++++--
- 3 files changed, 11 insertions(+), 37 deletions(-)
+ pyproject.toml | 39 +++++----------------------------------
+ setup.py       |  8 ++++++--
+ 2 files changed, 11 insertions(+), 36 deletions(-)
 
-diff --git a/Pyfhel.egg-info/SOURCES.txt b/Pyfhel.egg-info/SOURCES.txt
-index 1469508..564ebdf 100644
---- a/Pyfhel.egg-info/SOURCES.txt
-+++ b/Pyfhel.egg-info/SOURCES.txt
-@@ -4,7 +4,7 @@ README.md
- pyproject.toml
- setup.cfg
- setup.py
--/Users/alberto.ibarrondo/Technocracy/workspace/Pyfhel/Pyfhel/Afhel/Afseal.cpp
-+Pyfhel/Afhel/Afseal.cpp
- Pyfhel/PyCtxt.pxd
- Pyfhel/PyCtxt.pyx
- Pyfhel/PyPoly.pxd
 diff --git a/pyproject.toml b/pyproject.toml
-index 1c7579e..bf7c73d 100644
+index 1c7579e..bc99ff5 100644
 --- a/pyproject.toml
 +++ b/pyproject.toml
-@@ -97,44 +97,15 @@ platforms = ["Linux", "Windows", "Darwin"]
+@@ -96,45 +96,16 @@ platforms = ["Linux", "Windows", "Darwin"]
+ # - Libs in mode 'standard' are compiled using the default platform compiler.
  #------------------------------ C/C++ LIBRARIES --------------------------------
  [cpplibraries]
- 
+-
 -  #--> SEAL
 -  [cpplibraries.SEAL]
 -  mode = 'cmake'              # standard/cmake
@@ -58,7 +45,7 @@ index 1c7579e..bf7c73d 100644
 -    SEAL_USE_MSGSL = 'ON'       # ON/OFF,	Build with Microsoft GSL support.
 -    SEAL_USE_ZLIB	= 'ON'        # ON/OFF,	Build with ZLIB support.
 -    SEAL_USE_ZSTD	= 'ON'        # ON/OFF,	Build with Zstandard support.
--    
+     
    #--> Afhel
    [cpplibraries.Afhel]
    mode = 'standard'        # standard/cmake
@@ -93,14 +80,15 @@ index 1c7579e..bf7c73d 100644
  # List of extensions to compile. Custom compilation config can be defined for each
  [extensions.Pyfhel]
 diff --git a/setup.py b/setup.py
-index 02754c4..68d4bc8 100755
+index 02754c4..dd24581 100755
 --- a/setup.py
 +++ b/setup.py
-@@ -452,7 +452,10 @@ class SuperBuildClib(build_clib):
+@@ -452,7 +452,11 @@ class SuperBuildClib(build_clib):
                  f.write(f"add_compile_options({extra_c_args})\n")
              for d in build_info['include_dirs']:
                  f.write(f"include_directories(\"{d}\")\n")
 -            macros = [f"-d{m[0]}={m[1]}" for m in build_info['macros']]
++
 +            f.write("include_directories(\"$ENV{PREFIX}/Library/include\")\n")
 +            f.write("include_directories(\"$ENV{PREFIX}/Library/include/SEAL-4.1\")\n")
 +            
@@ -108,7 +96,7 @@ index 02754c4..68d4bc8 100755
              if macros:
                  f.write(f"add_compile_options({' '.join(macros)})\n")
              extra_l_args = ' '.join(build_info['extra_link_args'])
-@@ -624,7 +627,7 @@ for ext_name, ext_conf in extensions.items():
+@@ -624,7 +628,7 @@ for ext_name, ext_conf in extensions.items():
          name            = ext_conf.pop('fullname', f"{project_name}.{ext_name}"),
          sources         =_npath(_pl(ext_conf.pop('sources', []))),
          include_dirs    = _path(_pl(ext_conf.pop('include_dirs', [])))      + include_dirs,


### PR DESCRIPTION
pyfhel 3.4.2 :snowflake:

**Destination channel:** Snowflake

### Links

- [PKG-3782]
- dev_url: https://github.com/ibarrond/Pyfhel/tree/v3.4.2
- pypi: https://pypi.org/project/Pyfhel/
- inspector: https://inspector.pypi.io/project/pyfhel/3.4.2/

### Explanation of changes:

- new feedstock, not on conda-forge
- unvendor `seal`

### TODOs

- [x] The `missing_dso_whitelist` for `osx` needs to be double-checked: verify that the files are there. **UPDATE: The files are there**, [see complete conda-debug log here](https://anaconda.atlassian.net/browse/PKG-3782?focusedCommentId=211419).
- [x] For `win` we need to set the include for `seal`'s headers to `%PREFIX%\Library\include\SEAL-4.1`. For some reason the trick in `bld.bat` does not work, and the compiler fails to find `seal`'s headers.
- [x] For `win` the two `SEAL_USE_ZSTD` and `SEAL_USE_ZLIB` are not properly set (see log).
- [x] `win` builds, but can't `import Pyfhel`, something is missing. **UPDATE: time is over**, we will skip `win`.
- [x] Tests are missing. **UPDATE: tests added**
- [x] `osx` has a python `Abort trap: 6` **UPDATE: I was not able to solve it, time is over, skip `osx`**

[PKG-3782]: https://anaconda.atlassian.net/browse/PKG-3782?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ